### PR TITLE
feat: add last result in view api monitor list

### DIFF
--- a/apimonitor/serializers.py
+++ b/apimonitor/serializers.py
@@ -74,12 +74,29 @@ class APIMonitorSerializer(serializers.ModelSerializer):
             'body_form',
             'raw_body',
         ]
+        
+        
+class APIMonitorResultSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = APIMonitorResult
+        fields = [
+            'id',
+            'monitor',
+            'execution_time',
+            'date',
+            'hour',
+            'minute',
+            'response_time',
+            'success',
+            'log_response',
+        ]
 
 
-class APIMonitorRetrieveSerializer(APIMonitorSerializer):
+class APIMonitorListSerializer(APIMonitorSerializer):
     success_rate = serializers.DecimalField(None, decimal_places=1)
     avg_response_time = serializers.IntegerField()
     success_rate_history = APIMonitorSuccessRateHistorySerializer(many=True)
+    last_result = APIMonitorResultSerializer()
     
     class Meta:
         model = APIMonitor
@@ -97,4 +114,5 @@ class APIMonitorRetrieveSerializer(APIMonitorSerializer):
             'success_rate',
             'avg_response_time',
             'success_rate_history',
+            'last_result',
         ]

--- a/apimonitor/tests.py
+++ b/apimonitor/tests.py
@@ -1,3 +1,4 @@
+import json
 import pytz
 from datetime import datetime
 
@@ -143,6 +144,17 @@ class ListAPIMonitor(APITestCase):
                     }
                 ],
                 "id": 1,
+                "last_result": {
+                    "date": "2022-09-20",
+                    "execution_time": "2022-09-20T10:00:00+07:00",
+                    "hour": 9,
+                    "id": 4,
+                    "log_response": "{}",
+                    "minute": 0,
+                    "monitor": 1,
+                    "response_time": 50,
+                    "success": False
+                },
                 "method": "GET",
                 "name": "Test Monitor",
                 "query_params": [
@@ -398,6 +410,7 @@ class ListAPIMonitor(APITestCase):
                     }
                 ],
                 "id": 1,
+                "last_result": None,
                 "method": "GET",
                 "name": "Test Monitor",
                 "query_params": [

--- a/apimonitor/views.py
+++ b/apimonitor/views.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from apimonitor.models import APIMonitor, APIMonitorResult
-from apimonitor.serializers import APIMonitorSerializer, APIMonitorRetrieveSerializer
+from apimonitor.serializers import APIMonitorSerializer, APIMonitorListSerializer
 
 
 class APIMonitorViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
@@ -99,8 +99,12 @@ class APIMonitorViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
                 date_time_sc += timedelta(hours=1)
            
             monitor.success_rate_history = success_rate_history
+            
+            # Last result 
+            last_result = APIMonitorResult.objects.filter(monitor=monitor).last()
+            monitor.last_result = last_result
         
-        serializer = APIMonitorRetrieveSerializer(queryset, many=True)
+        serializer = APIMonitorListSerializer(queryset, many=True)
         return Response(serializer.data)
     
     


### PR DESCRIPTION
### Describe your changes
Add last result data in view api monitor list
Resolve #25 

### Backlog name
[MON-60: add last update on view list API monitor backend](https://monapi.atlassian.net/browse/MON-60)

### Acceptance criteria
- Able to provide last result on view list API Monitor 

### Example Request
```
curl --location --request GET 'http://localhost:8000/monitor/' \
--header 'Authorization: Token 75afe1bfa55e939b65d672a36555baab77092373'
```
```
[
    {
        "id": 1,
        "name": "Test",
        "method": "GET",
        "url": "/test/",
        "schedule": "1MIN",
        "body_type": "EMPTY",
        "query_params": [],
        "headers": [],
        "body_form": [],
        "raw_body": [],
        "success_rate": "100.0",
        "avg_response_time": 0,
        "success_rate_history": [
            {
                "date": "2022-10-02",
                "hour": 23,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 0,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 1,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 2,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 3,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 4,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 5,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 6,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 7,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 8,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 9,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 10,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 11,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 12,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 13,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 14,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 15,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 16,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 17,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 18,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 19,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 20,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 21,
                "minute": 0,
                "success": 0,
                "failed": 0
            },
            {
                "date": "2022-10-03",
                "hour": 22,
                "minute": 0,
                "success": 0,
                "failed": 0
            }
        ],
        "last_result": {
            "id": 3,
            "monitor": 1,
            "execution_time": "2022-10-02T00:07:39+07:00",
            "date": "2022-10-02",
            "hour": 0,
            "minute": 0,
            "response_time": 100,
            "success": false,
            "log_response": "0"
        }
    }
]
```

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
