### PR TITLE
refactor: change log error on assertion text failed

### DIFF
--- a/cron/management/commands/run_cron.py
+++ b/cron/management/commands/run_cron.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
     def run_api_monitor_assertions(self, monitor_id, response):
         monitor = APIMonitor.objects.get(id=monitor_id)
         if monitor.assertion_type == 'TEXT' and response != monitor.assertion_value:
-            raise AssertionError('Assertion text failed')
+            raise AssertionError(f'Assertion text failed.\nExpected: "{monitor.assertion_value}"\nGot: "{response}"')
         elif monitor.assertion_type == 'JSON':
             try:
                 api_response = json.loads(response) 

--- a/cron/tests.py
+++ b/cron/tests.py
@@ -915,7 +915,7 @@ class CronManagementCommand(TransactionTestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].success, False)
         self.assertEqual(result[0].log_response, "NonJSON response")
-        self.assertEqual(result[0].log_error, 'Assertion text failed')
+        self.assertEqual(result[0].log_error, 'Assertion text failed.\nExpected: ""\nGot: "NonJSON response"')
         
     @patch("cron.management.commands.run_cron.mock_cron_interrupt", side_effect=InterruptedError)
     @patch("requests.get", mocked_request_get)


### PR DESCRIPTION
### Describe your changes
[REFACTOR] change log error on assertion text failed

### Backlog name
PBI-16: cron api assertions

### Acceptance criteria
- User can add expected result (json, text) on Create new API monitor, edit API monitor page
- API Monitor can assert response of each API and give error if failed to assert



### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
