### PR TITLE
fix: bug fix cron multi step wrong monitor id

### DIFF
--- a/cron/management/commands/run_cron.py
+++ b/cron/management/commands/run_cron.py
@@ -166,19 +166,19 @@ class Command(BaseCommand):
                     log_error=f"Request aborted due to recursion of API monitor steps"
                 )
                 
-            result = self.run_api_monitor_request(monitor.previous_step.id, monitor_history)
-            if not result.success:
+            prev_result = self.run_api_monitor_request(monitor.previous_step.id, monitor_history)
+            if not prev_result.success:
                 return APIMonitorResult(
                     monitor=monitor,
                     success=False,
                     status_code=result.status_code,
                     log_response=result.log_response,
-                    log_error=f"Error on previous step: {result.monitor.name}\n" + result.log_error,
+                    log_error=f"Error on previous step: {prev_result.monitor.name}\n" + prev_result.log_error,
                 )
                 
             # Extract json from log response if possible
             try:
-                previous_json = json.loads(result.log_response)
+                previous_json = json.loads(prev_result.log_response)
             except json.decoder.JSONDecodeError:
                 pass
         

--- a/cron/tests.py
+++ b/cron/tests.py
@@ -828,7 +828,7 @@ class CronManagementCommand(TransactionTestCase):
         result = APIMonitorResult.objects.all()
         self.assertEqual(len(result), 2)
         self.assertEqual(result[1].success, False)
-        self.assertEqual(result[1].log_response, "{\"testing\": \"testing value\"}")
+        self.assertEqual(result[1].log_response, "")
         self.assertIn('Error while preparing API monitor params: \'Value not found while accessing with key "testing.testing"\'', result[1].log_error)
         
     @patch("cron.management.commands.run_cron.mock_cron_interrupt", side_effect=InterruptedError)


### PR DESCRIPTION
### Describe your changes
Bug fix cron multi step wrong monitor id

### Backlog name
PBI-16: api assertions

### Acceptance criteria
- User can add expected result (json, text) on Create new API monitor and edit API monitor page
- API Monitor can assert response of each API and give error if failed to assert


### Example Request
![image](https://user-images.githubusercontent.com/28893391/198857912-77c008b0-48ce-4f1d-8f5b-9eb6abf72251.png)


### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
