### PR TITLE
fix: fix missing team mapping on migrations

### DIFF
--- a/apimonitor/migrations/0014_remove_alertsconfiguration_user_and_more.py
+++ b/apimonitor/migrations/0014_remove_alertsconfiguration_user_and_more.py
@@ -3,7 +3,6 @@
 from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
-from django.contrib.auth.models import User
 
 
 def forwards_func(apps, schema_editor):
@@ -12,11 +11,15 @@ def forwards_func(apps, schema_editor):
     db_alias = schema_editor.connection.alias
     
     Team = apps.get_model("login", "Team")
+    TeamMember = apps.get_model("login", "TeamMember")
+    User = apps.get_model("auth", "User")
+    
     users = User.objects.using(db_alias).all()
     team_mapping = {}
     for user in users:
         username = user.username.split('@')[0]
-        team = Team.objects.create(name=username.title())
+        team = Team.objects.using(db_alias).create(name=username.title())
+        TeamMember.objects.using(db_alias).create(team=team, user=user)
         team_mapping[user.id] = team
     
     APIMonitor = apps.get_model("apimonitor", "APIMonitor")

--- a/login/tests.py
+++ b/login/tests.py
@@ -123,6 +123,7 @@ class CurentTeamTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['id'], team.id)
         
+
 class AvailableTeamTest(APITestCase):
     available_team_url = reverse('auth-available-team')
 

--- a/login/tests.py
+++ b/login/tests.py
@@ -123,7 +123,6 @@ class CurentTeamTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['id'], team.id)
         
-
 class AvailableTeamTest(APITestCase):
     available_team_url = reverse('auth-available-team')
 


### PR DESCRIPTION
### Describe your changes
fix missing team mapping on migrations

### Backlog name
PBI-28: Team authentication


### Acceptance criteria
- User able to login using user account and access to team data
- User able to change current session to another team


### Example Request


### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
