### PR TITLE
feat: PBI-28 team authentication add new team when register

### DIFF
--- a/register/tests.py
+++ b/register/tests.py
@@ -3,6 +3,8 @@ from rest_framework import status
 from django.urls import reverse
 from django.contrib.auth.models import User
 
+from login.models import Team, TeamMember
+
 
 class APIViewTestCase(APITestCase):
     def test_user_can_register(self):
@@ -24,6 +26,11 @@ class APIViewTestCase(APITestCase):
         new_user = User.objects.get_by_natural_key("user1@gmail.com")
         self.assertEqual(new_user.get_username(), "user1@gmail.com")
         self.assertEqual(new_user.check_password('B0tch1ng'), True)
+        
+        self.assertEqual(Team.objects.count(), 1)
+        self.assertEqual(Team.objects.all()[0].name, "User1")
+        self.assertEqual(TeamMember.objects.count(), 1)
+        self.assertEqual(TeamMember.objects.all()[0].user, new_user)
 
     def test_user_password_must_match(self):
         response = self.client.post(

--- a/register/views.py
+++ b/register/views.py
@@ -4,6 +4,7 @@ from rest_framework import status
 
 from django.db.utils import IntegrityError
 from register.serializers import RegistrationSerializer
+from login.models import Team, TeamMember
 
 @api_view(['POST', ])
 @authentication_classes([])
@@ -14,6 +15,9 @@ def registration_view(request):
     if serializer.is_valid():
         try:
             user = serializer.save()
+            username = user.username.split('@')[0]
+            team = Team.objects.create(name=username.title())
+            TeamMember.objects.create(user=user, team=team, verified=True)
         except IntegrityError:
             data['response'] = 'User already registered! Please use a different email to register.'
             return Response(data, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
### Describe your changes
Automatically create new team when user register

### Backlog name
PBI-28: team authentication

### Acceptance criteria
- New team created when user register

### Example Request
```
curl --location --request POST 'http://localhost:8000/register/api' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "admin3@admin.com",
    "password": "Monapi123",
    "password2": "Monapi123"
}'
```
```
{
    "response": "Successfully registered new user.",
    "email": "admin3@admin.com"
}
```

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
