### PR TITLE
[FIX] Override permission on accept invite team

### DIFF
--- a/invite_team_members/tests.py
+++ b/invite_team_members/tests.py
@@ -129,14 +129,14 @@ class AcceptInviteViewTest(APITestCase):
         self.default_invite_token = InviteTeamMemberToken.objects.create(team_member=self.default_team_member)
 
     def test_frontend_sends_no_data(self):
-        response = self.client.post(self.test_url, {}, format='json', **self.default_header)
+        response = self.client.post(self.test_url, {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {"key": ["This field is required."]})
 
     def test_invite_already_verified_user(self):
         response = self.client.post(self.test_url, {
             'key': self.default_invite_token.key
-        }, format='json', **self.default_header)
+        }, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'error': 'You are already a member of the team'})
 
@@ -165,7 +165,7 @@ class AcceptInviteViewTest(APITestCase):
         invite_token_key = invite_token.key
         response = self.client.post(self.test_url, {
             'key': invite_token_key
-        }, format='json', **self.default_header)
+        }, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'error': 'Invalid token'})
         self.assertEqual(InviteTeamMemberToken.objects.all().count(), 1)

--- a/invite_team_members/views.py
+++ b/invite_team_members/views.py
@@ -82,6 +82,8 @@ class RequestInviteTeamMemberTokenView(views.APIView):
 
 
 class AcceptInviteView(views.APIView):
+    authentication_classes = []
+    permission_classes = []
     def post(self, request, format=None):
         serializer = AcceptInviteSerializer(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
### Describe your changes
Make it so that you do not need to be logged in to accept team invite

### Checklist
- [X] I have performed a self-review of my code
- [X] Code successfully run on local
- [X] Feature / changes tested on local
- [X] No failing unit test
- [ ] Passed UAT Test
- [X] Sonarqube tested 
- [ ] Required any changes to environment variable
