### PR TITLE
fix: change conditional logic edit team

### DIFF
--- a/team_management/views.py
+++ b/team_management/views.py
@@ -42,8 +42,9 @@ class TeamManagementViewSet(mixins.CreateModelMixin,
 				return Response(data={"error": "Team name cannot be changed!"}, status=status.HTTP_400_BAD_REQUEST)
 			
 			# remove old image
-			if (request.data.get('logo') is not None and team.logo and os.path.exists(team.logo.path)):
-				os.remove(team.logo.path)
+			if request.data.get('logo') is not None :
+				if (team.logo and os.path.exists(team.logo.path)):
+					os.remove(team.logo.path)
 				team.logo = request.data.get('logo')
 
 			if (request.data.get('description') is not None):


### PR DESCRIPTION
### Describe your changes
Fix endpoint for edit team profile

### Backlog name
[PBI-26 edit team profile](https://monapi.atlassian.net/browse/MON-101?atlOrigin=eyJpIjoiMjBlY2RkMGJhM2VhNDgwYjlmNzhiOWJkZjY4MmY2MmEiLCJwIjoiaiJ9)

### Acceptance criteria
- User can edit team description and team logo
- Team name cannot be changed
- Previously saved image, when changed, is deleted

### Example Request
Request
```
curl --location --request PUT 'http://localhost:8000/team-management/' \
--header 'Authorization: Token xxx' \
--header 'Content-Type: application/json' \
--data-raw '{
    "description": "123",
    "logo": "picture.png"
}'
```
Response status 200 OK
```
{
    "id": xx,
    "name": "test team"
}
```

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
