### PR TITLE
feat: PBI-33-status page dashboard-Backend

### DIFF
--- a/statuspage/serializers.py
+++ b/statuspage/serializers.py
@@ -18,3 +18,19 @@ class StatusPageCategorySerializers(serializers.ModelSerializer):
             'team',
             'name',
         ]
+
+class APIMonitorSuccessRateSerializer(serializers.Serializer):
+    start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
+    success = serializers.IntegerField()
+    failed = serializers.IntegerField()
+
+class StatusPageDashboardSerializers(serializers.ModelSerializer):
+    success_rate_category = APIMonitorSuccessRateSerializer(many=True)
+    class Meta:
+        model = StatusPageCategory
+        fields = [
+            'id',
+            'name',
+            'success_rate_category',
+        ]

--- a/statuspage/tests.py
+++ b/statuspage/tests.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 from rest_framework.test import APITestCase
 from login.models import Team, TeamMember, MonAPIToken
+from apimonitor.models import APIMonitor, APIMonitorResult
 from statuspage.models import StatusPageConfiguration, StatusPageCategory
 
 class StatusPageConfigTest(APITestCase):
@@ -176,4 +177,79 @@ class StatusPageCategoryTest(APITestCase):
         response = self.client.delete(reverse('statuspage-category-detail', kwargs={'pk': 999}), format='json', **header)
         self.assertEqual(response.status_code, 404)
         
+        
+class StatusPageDashboardTest(APITestCase):
+    test_url = reverse('statuspage-dashboard')
+    local_timezone = pytz.timezone(settings.TIME_ZONE)
+    mock_current_time = local_timezone.localize(datetime(2022, 9, 20, 10))
+
+    def setUp(self):
+        # Mock time function
+        timezone.now = lambda: self.mock_current_time
+        
+    # status page dashboard deservedly access without authorization because for public
+    def test_unauthorized_and_not_empty_status_page_category_in_api_monitor_then_return_success(self):
+        # create dummy api monitor and the result
+        team = Team.objects.create(name='test team')
+        statusPageCategory1 = StatusPageCategory.objects.create(team=team, name='test-category1')
+        statusPageCategory2 = StatusPageCategory.objects.create(team=team, name='test-category2')
+        StatusPageConfiguration.objects.create(team=team, path='test-path')
+
+        monitor1 = APIMonitor.objects.create(
+            team=team,
+            name='Test Name1',
+            method='GET',
+            url='Test Path',
+            schedule='10MIN',
+            previous_step=None,
+            body_type='EMPTY',
+            status_page_category=statusPageCategory1,
+        )
+
+        monitor2 = APIMonitor.objects.create(
+            team=team,
+            name='Test Name2',
+            method='GET',
+            url='Test Path',
+            schedule='10MIN',
+            previous_step=None,
+            body_type='EMPTY',
+            status_page_category=statusPageCategory2,
+        )
+
+        APIMonitorResult.objects.create(
+            monitor=monitor1,
+            execution_time=self.mock_current_time,
+            response_time=100,
+            success=True,
+            status_code=500,
+            log_response='Log Response',
+            log_error='',
+        )
+
+        APIMonitorResult.objects.create(
+            monitor=monitor2,
+            execution_time=self.mock_current_time,
+            response_time=75,
+            success=False,
+            status_code=500,
+            log_response='',
+            log_error='Log Error'
+        )
+
+        response = self.client.get(self.test_url, data={"path": "test-path"}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['name'], 'test-category1')
+        self.assertEqual(response.data[0]['success_rate_category'][23]['success'], 1)
+        self.assertEqual(response.data[1]['success_rate_category'][23]['failed'], 1)
+        
+    def test_unauthorized_and_empty_status_page_category_then_return_empty_status_page_dashboard(self):
+        # create path
+        team = Team.objects.create(name='test team')
+        StatusPageConfiguration.objects.create(team=team, path='test-path')
+
+        response = self.client.get(self.test_url, data={"path": "test-path"}, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 0)
         

--- a/statuspage/urls.py
+++ b/statuspage/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, include
 from rest_framework import routers
-from statuspage.views import StatusPageConfigurationView, StatusPageCategoryViewSet
+from statuspage.views import StatusPageConfigurationView, StatusPageCategoryViewSet, StatusPageDashboardViewSet
 
 router = routers.DefaultRouter()
 router.register(r'', StatusPageCategoryViewSet, basename='statuspage-category')
 
 urlpatterns = [
     path('category/', include(router.urls)),
-    path('config/', StatusPageConfigurationView.as_view(), name='statuspage-config')
+    path('config/', StatusPageConfigurationView.as_view(), name='statuspage-config'),
+    path('dashboard/', StatusPageDashboardViewSet.as_view({'get': 'list'}), name='statuspage-dashboard'),
 ]

--- a/statuspage/views.py
+++ b/statuspage/views.py
@@ -1,10 +1,13 @@
-from django.shortcuts import render
+from datetime import timedelta
+from django.db.models import Count, Q
+from django.utils import timezone
 from rest_framework import views, status, viewsets, mixins
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from apimonitor.models import APIMonitorResult
 from statuspage.models import StatusPageConfiguration, StatusPageCategory
-from statuspage.serializers import StatusPageConfgurationSerializers, StatusPageCategorySerializers
+from statuspage.serializers import StatusPageConfgurationSerializers, StatusPageCategorySerializers, StatusPageDashboardSerializers
 
 class StatusPageConfigurationView(views.APIView):
     permission_classes = [IsAuthenticated]
@@ -42,3 +45,54 @@ class StatusPageCategoryViewSet(mixins.ListModelMixin,
         request.data['team'] = request.auth.team.pk
         return super().create(request, *args, **kwargs)
     
+
+class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+    
+    queryset = StatusPageCategory.objects.all()
+    serializer_class = StatusPageDashboardSerializers
+    permission_classes = []
+    pagination_class = None
+
+    def list(self, request):
+        statusPageConfig = StatusPageConfiguration.objects.filter(path=self.request.GET.get('path'))
+        if len(statusPageConfig) == 0:
+            return Response(data={"error": "Please make sure your URL path is exist!"}, status=status.HTTP_404_NOT_FOUND)
+        
+        queryset = StatusPageCategory.objects.filter(team=statusPageConfig[0].team)
+
+        for category in queryset:
+            success_rate_category = []
+            ApiMonitorCategory = APIMonitorResult.objects \
+                .filter(monitor__team=statusPageConfig[0].team, monitor__status_page_category=category)
+
+            if len(ApiMonitorCategory) == 0:
+                category.success_rate_category = success_rate_category
+                continue
+            
+            #success_rate per category
+            last_24_hour = timezone.now() - timedelta(hours=24)
+            for _ in range(24):
+                start_time = last_24_hour
+                end_time = last_24_hour + timedelta(hours=1)
+                
+                # Average success rate
+                success_count = ApiMonitorCategory.filter(execution_time__gte=start_time, execution_time__lte=end_time) \
+                    .aggregate(
+                        s=Count('success', filter=Q(success=True)), 
+                        f=Count('success', filter=Q(success=False)),
+                        total=Count('pk'),
+                    )
+
+                success_rate_category.append({
+                    "start_time": start_time,
+                    "end_time" : end_time,
+                    "success": success_count['s'],
+                    "failed" : success_count['f']
+                })
+
+                last_24_hour += timedelta(hours=1)
+
+            category.success_rate_category = success_rate_category
+
+        serializer = StatusPageDashboardSerializers(queryset, many=True)
+        return Response(serializer.data)

--- a/statuspage/views.py
+++ b/statuspage/views.py
@@ -54,18 +54,18 @@ class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
     pagination_class = None
 
     def list(self, request):
-        statusPageConfig = StatusPageConfiguration.objects.filter(path=self.request.GET.get('path'))
-        if len(statusPageConfig) == 0:
+        status_page_config = StatusPageConfiguration.objects.filter(path=self.request.GET.get('path'))
+        if len(status_page_config) == 0:
             return Response(data={"error": "Please make sure your URL path is exist!"}, status=status.HTTP_404_NOT_FOUND)
         
-        queryset = StatusPageCategory.objects.filter(team=statusPageConfig[0].team)
+        queryset = StatusPageCategory.objects.filter(team=status_page_config[0].team)
 
         for category in queryset:
             success_rate_category = []
-            ApiMonitorCategory = APIMonitorResult.objects \
-                .filter(monitor__team=statusPageConfig[0].team, monitor__status_page_category=category)
+            api_monitor_category = APIMonitorResult.objects \
+                .filter(monitor__team=status_page_config[0].team, monitor__status_page_category=category)
 
-            if len(ApiMonitorCategory) == 0:
+            if len(api_monitor_category) == 0:
                 category.success_rate_category = success_rate_category
                 continue
             
@@ -76,7 +76,7 @@ class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
                 end_time = last_24_hour + timedelta(hours=1)
                 
                 # Average success rate
-                success_count = ApiMonitorCategory.filter(execution_time__gte=start_time, execution_time__lte=end_time) \
+                success_count = api_monitor_category.filter(execution_time__gte=start_time, execution_time__lte=end_time) \
                     .aggregate(
                         s=Count('success', filter=Q(success=True)), 
                         f=Count('success', filter=Q(success=False)),

--- a/statuspage/views.py
+++ b/statuspage/views.py
@@ -63,7 +63,7 @@ class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
         for category in queryset:
             success_rate_category = []
             api_monitor_category = APIMonitorResult.objects \
-                .filter(monitor__team=status_page_config[0].team, monitor__status_page_category=category)
+                .filter(monitor__status_page_category=category)
 
             if len(api_monitor_category) == 0:
                 category.success_rate_category = success_rate_category


### PR DESCRIPTION
### Describe your changes
- Implements status page dashboard

### Backlog name
[Status Page Dashboard - Backend](https://monapi.atlassian.net/browse/MON-116)

### Acceptance criteria
User can see API monitor status through status page based on configured category

### Example Request (No Need Authorization)
Request
```
curl --location --request GET 'http://127.0.0.1:8000/status-page/dashboard/?path=testpath' 
```
Response (success_rate_category has 24 objects as hour, or an empty list if the category has not been assigned in API Monitor)
```
[
    {
        "id": 1,
        "name": "testcategory",
        "success_rate_category": []
    },
    {
        "id": 2,
        "name": "testcategory2",
        "success_rate_category": [
            {
                "start_time": "2022-11-29T18:44:45.495439+07:00",
                "end_time": "2022-11-29T19:44:45.495439+07:00",
                "success": 0,
                "failed": 0
            },
           ......
            {
                "start_time": "2022-11-30T17:44:45.495439+07:00",
                "end_time": "2022-11-30T18:44:45.495439+07:00",
                "success": 0,
                "failed": 0
            }
        ]
    }
]
```


### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [ ] Passed UAT Test
- [x] Sonarqube tested 
- [ ] Required any changes to environment variable
