### PR TITLE
feat: Pbi 34 add partial assertion text backend

### DIFF
--- a/apimonitor/models.py
+++ b/apimonitor/models.py
@@ -34,6 +34,7 @@ class APIMonitor(models.Model):
         ('DISABLED', 'Disabled'),
         ('TEXT', 'Text'),
         ('JSON', 'JSON'),
+        ('PARTIAL', 'Partial'),
     ]
     
     team = models.ForeignKey(Team, on_delete=models.CASCADE)

--- a/cron/management/commands/run_cron.py
+++ b/cron/management/commands/run_cron.py
@@ -83,6 +83,8 @@ class Command(BaseCommand):
         monitor = APIMonitor.objects.get(id=monitor_id)
         if monitor.assertion_type == 'TEXT' and response != monitor.assertion_value:
             raise AssertionError(f'Assertion text failed.\nExpected: "{monitor.assertion_value}"\nGot: "{response}"')
+        elif monitor.assertion_type == 'PARTIAL' and not monitor.assertion_value in response:
+            raise AssertionError(f'Partial Assertion text failed.\nExpected: "{monitor.assertion_value}"\nGot: "{response}"')
         elif monitor.assertion_type == 'JSON':
             try:
                 api_response = json.loads(response) 


### PR DESCRIPTION
### Describe your changes
Implement partial text assertion

### Backlog name
Pbi 34 add partial assertion text backend

### Acceptance criteria
- Please copy acceptance criteria from backlog info

### Example Request
```
curl --location --request POST 'localhost:8000/monitor/' \
--header 'Authorization: Token cf4cd79558b13d974144c2ab82968046e6c400c2' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Test Partial Text Assertion",
    "method": "GET",
    "url": "https://monapinonjson.xyz",
    "schedule": "1MIN",
    "body_type": "RAW",
    "query_params": [
        {
            "key": "qp_key1",
            "value": "qp_value1"
        },
        {
            "key": "qp_key2",
            "value": "qp_value2"
        }
    ],
    "headers": [
        {
            "key": "h_key1",
            "value": "h_value1"
        }
    ],
    "body_form": "Doesn'\''t matter because body_type is RAW, can be None",
    "raw_body": "Test raw body",
    "assertion_type":"PARTIAL",
    "assertion_value":"NonJSON"
}'
```
```
{
    "id": 25,
    "name": "Test Partial Text Assertion",
    "method": "GET",
    "url": "https://monapinonjson.xyz",
    "schedule": "1MIN",
    "body_type": "RAW",
    "query_params": [
        {
            "id": 23,
            "monitor": 25,
            "key": "qp_key1",
            "value": "qp_value1"
        },
        {
            "id": 24,
            "monitor": 25,
            "key": "qp_key2",
            "value": "qp_value2"
        }
    ],
    "headers": [
        {
            "id": 12,
            "monitor": 25,
            "key": "h_key1",
            "value": "h_value1"
        }
    ],
    "body_form": [],
    "raw_body": {
        "id": 12,
        "monitor": 25,
        "body": "Test raw body"
    },
    "previous_step_id": null,
    "assertion_type": "PARTIAL",
    "assertion_value": "NonJSON",
    "is_assert_json_schema_only": false,
    "exclude_keys": []
}
```

### Checklist
- [ ] I have performed a self-review of my code
- [ ] Code successfully run on local
- [ ] Feature / changes tested on local
- [ ] No failing unit test
- [ ] Passed UAT Test
- [ ] Sonarqube tested 
- [ ] Required any changes to environment variable
