### PR TITLE
feat: change status page dashboard query and add forget password validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Full release notes can be found in [Release Notes](https://github.com/MonAPI-xyz
 
 📝  [User Manual - https://docs.monapi.xyz](https://docs.monapi.xyz)
 
+📝  [Technical Documentation - https://docs.monapi.xyz/monapi-tech-documentation/](https://docs.monapi.xyz/monapi-tech-documentation/)
+
+📺  [Youtube - https://www.youtube.com/@monapi](https://www.youtube.com/@monapi)
+
+
 ## Our Teams
 - Lucky Susanto
 - Ferdi Fadillah

--- a/forget_password/serializers.py
+++ b/forget_password/serializers.py
@@ -1,4 +1,6 @@
 from rest_framework import serializers
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError
 
 
 class RequestForgetPasswordTokenSerializer(serializers.Serializer):
@@ -12,3 +14,10 @@ class ForgetPasswordTokenCheckSerializer(serializers.Serializer):
 class ResetPasswordSerializer(serializers.Serializer):
     password = serializers.CharField(max_length=128)
     key = serializers.CharField(max_length=256)
+    
+    def validate_password(self, password):
+        try:
+            validate_password(password)
+        except ValidationError as exc:
+            raise exc
+        return password

--- a/forget_password/tests.py
+++ b/forget_password/tests.py
@@ -86,32 +86,47 @@ class ResetPasswordTest(APITestCase):
     def test_if_key_exists_but_token_invalid_then_return_error(self):
         response = self.client.post(self.test_url, {
             'key': 'abc',
-            'password': 'newpassword',
+            'password': 'Test123486827',
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'error': 'Invalid token'})
         
     def test_if_key_exists_and_token_valid__and_pasword_same_as_old_then_return_error(self):
-        user = User.objects.create_user(username='test', email='test@test.com', password='test123')
+        user = User.objects.create_user(username='test', email='test@test.com', password='Test123486827')
         token = ForgetPasswordToken.objects.create(user=user)
         response = self.client.post(self.test_url, {
             'key': token.key,
-            'password': 'test123',
+            'password': 'Test123486827',
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data, {'error': 'Please choose password that different from your current password'})
         
-    def test_if_key_exists_and_token_valid_then_return_success(self):
-        user = User.objects.create_user(username='test', email='test@test.com', password='test123')
+    def test_if_key_exists_token_valid_but_invalid_password_then_return_error(self):
+        user = User.objects.create_user(username='test', email='test@test.com', password='Test123486827')
         token = ForgetPasswordToken.objects.create(user=user)
         response = self.client.post(self.test_url, {
             'key': token.key,
-            'password': 'newpassword',
+            'password': 'abc',
+        }, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {"password": [
+            "This password is too short. It must contain at least 8 characters.",
+            "This password is too common.",
+            "The password must contain at least 1 digit, 0-9.",
+            "The password must contain at least 1 uppercase letter, A-Z."
+        ]})
+        
+    def test_if_key_exists_and_token_valid_then_return_success(self):
+        user = User.objects.create_user(username='test', email='test@test.com', password='Test123486827')
+        token = ForgetPasswordToken.objects.create(user=user)
+        response = self.client.post(self.test_url, {
+            'key': token.key,
+            'password': 'Test1234868271',
         }, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, {'success': True})
         
         user = User.objects.get(email='test@test.com')
-        self.assertTrue(user.check_password('newpassword'))
+        self.assertTrue(user.check_password('Test1234868271'))
     
     

--- a/statuspage/views.py
+++ b/statuspage/views.py
@@ -69,10 +69,10 @@ class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
 
         for category in queryset:
             success_rate_category = []
-            api_monitor_category = APIMonitorResult.objects \
-                .filter(monitor__status_page_category=category)
+            api_monitor_result_count = APIMonitorResult.objects \
+                .filter(monitor__status_page_category=category).count()
 
-            if len(api_monitor_category) == 0:
+            if api_monitor_result_count == 0:
                 category.success_rate_category = success_rate_category
                 continue
             
@@ -83,12 +83,15 @@ class StatusPageDashboardViewSet(mixins.ListModelMixin, viewsets.GenericViewSet)
                 end_time = last_24_hour + timedelta(hours=1)
                 
                 # Average success rate
-                success_count = api_monitor_category.filter(execution_time__gte=start_time, execution_time__lte=end_time) \
-                    .aggregate(
-                        s=Count('success', filter=Q(success=True)), 
-                        f=Count('success', filter=Q(success=False)),
-                        total=Count('pk'),
-                    )
+                success_count = APIMonitorResult.objects.filter(
+                    monitor__status_page_category=category, 
+                    execution_time__gte=start_time, 
+                    execution_time__lte=end_time
+                ).aggregate(
+                    s=Count('success', filter=Q(success=True)), 
+                    f=Count('success', filter=Q(success=False)),
+                    total=Count('pk'),
+                )
 
                 success_rate_category.append({
                     "start_time": start_time,


### PR DESCRIPTION
### Describe your changes
Change status page dashboard query and add forget password validation

### Backlog name

### Acceptance criteria
- Password is validated on forget password flow

### Example Request
```
curl --location --request POST 'http://localhost:8000/forget-password/change/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "key": "68708b28-4da4-4c88-a9e3-1c9efd3f1484",
    "password": "abc"
}'
```
```
{
    "password": [
        "['This password is too short. It must contain at least 8 characters.', 'This password is too common.', 'The password must contain at least 1 digit, 0-9.', 'The password must contain at least 1 uppercase letter, A-Z.']"
    ]
}
```

### Checklist
- [x] I have performed a self-review of my code
- [x] Code successfully run on local
- [x] Feature / changes tested on local
- [x] No failing unit test
- [x] Passed UAT Test
- [ ] Sonarqube tested 
- [x] Required any changes to environment variable
